### PR TITLE
hwdb: fixed modalias for One-netbook OneMix 2s

### DIFF
--- a/hwdb.d/60-sensor.hwdb
+++ b/hwdb.d/60-sensor.hwdb
@@ -693,7 +693,7 @@ sensor:modalias:acpi:SMO8500*:dmi:bvnAmericanMegatrendsInc.:bvr5.6.5:bd07/25/201
 
 # One-netbook OneMix 2s
 # OneMix 2s has no product name filled, matching entire dmi-alias
-sensor:modalias:acpi:BOSC0200*:dmi:bvnAmericanMegatrendsInc.:bvr5.12:bd10/26/2018:br5.12:svnDefaultstring:pnDefaultstring:pvrDefaultstring:rvnDefaultstring:rnDefaultstring:rvrDefaultstring:cvnDefaultstring:ct3:cvrDefaultstring:*
+sensor:modalias:acpi:BOSC0200*:dmi:bvnAmericanMegatrendsInc.:bvr5.12:bd10/26/2018:br5.12:svnDefaultstring:pnDefaultstring:pvrDefaultstring:skuDefaultstring:rvnDefaultstring:rnDefaultstring:rvrDefaultstring:cvnDefaultstring:ct3:cvrDefaultstring:
  ACCEL_MOUNT_MATRIX=0, 1, 0; 1, 0, 0; 0, 0, 1
 
 # One-netbook OneMix 3 Pro


### PR DESCRIPTION
Original: [hwdb: add accel matrix for One-netbook OneMix 2s #20068 ](https://github.com/systemd/systemd/pull/20068#issue-680355660)
Problem: [Problem with hwdb accel matrix for One-netbook OneMix 2s #20550](https://github.com/systemd/systemd/issues/20550#issue-980328627)
Fixed [these](https://github.com/systemd/systemd/issues/20550#issuecomment-907016740)

I don't know if this is iio-sensor-proxy problem or is it my modalias but I show it here if it is any useful for something:
```
● iio-sensor-proxy.service - IIO Sensor Proxy service
     Loaded: loaded (/usr/lib/systemd/system/iio-sensor-proxy.service; static)
     Active: active (running) since Sat 2021-08-28 15:53:14 EEST; 1min 4s ago
   Main PID: 314 (iio-sensor-prox)
      Tasks: 3 (limit: 9414)
     Memory: 1.3M
        CPU: 93ms
     CGroup: /system.slice/iio-sensor-proxy.service
             └─314 /usr/lib/iio-sensor-proxy

elo 28 15:53:14 antin-umpc systemd[1]: Starting IIO Sensor Proxy service...
elo 28 15:53:14 antin-umpc systemd[1]: Started IIO Sensor Proxy service.
elo 28 15:53:14 antin-umpc iio-sensor-prox[314]: Could not find trigger name associated with /sys/devices/pci0000:00/0000:00:15.0/i2c_designware.0/i2c-0/i2c-BOSC0200:00/iio:device0
```